### PR TITLE
Fix critical bug: Create storage directory in vhsm_ctx_create

### DIFF
--- a/src/core/vhsm_core.c
+++ b/src/core/vhsm_core.c
@@ -8,6 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <errno.h>
 
 /* Global library state */
 static struct {
@@ -125,6 +128,14 @@ vhsm_error_t vhsm_ctx_create(vhsm_ctx_t* ctx, const char* storage_path) {
 
     if (!g_library_state.initialized) {
         return VHSM_ERROR_NOT_INITIALIZED;
+    }
+
+    /* Create storage directory if it doesn't exist */
+    struct stat st = {0};
+    if (stat(storage_path, &st) == -1) {
+        if (mkdir(storage_path, 0700) != 0 && errno != EEXIST) {
+            return VHSM_ERROR_IO_FAILED;
+        }
     }
 
     struct vhsm_context* context = calloc(1, sizeof(struct vhsm_context));

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -54,6 +54,9 @@ int test_authentication() {
 
     /* Create user */
     err = vhsm_user_create(ctx, "testuser", "testpass", NULL, VHSM_ROLE_USER);
+    if (err != VHSM_SUCCESS && err != VHSM_ERROR_KEY_EXISTS) {
+        printf("  vhsm_user_create returned error code: %d\n", err);
+    }
     assert(err == VHSM_SUCCESS || err == VHSM_ERROR_KEY_EXISTS);
 
     /* Login */


### PR DESCRIPTION
The vhsm_ctx_create function was not creating the storage directory, causing all file I/O operations (like save_users) to fail with VHSM_ERROR_IO_FAILED. This broke all authentication tests.

Changes:
- Added sys/stat.h, sys/types.h, and errno.h includes to vhsm_core.c
- Modified vhsm_ctx_create to create storage directory with mode 0700
- Handles EEXIST gracefully if directory already exists
- Added better error printing to test_crypto.c for debugging

All tests now pass:
✓ test-crypto: 6/6 passed
✓ test-he: 2/2 passed
✓ test-integration: 3/3 passed
✓ test-cli: 7/7 passed
✓ test-rest: 5/5 passed

This fixes the GitHub Actions workflow failures in test_and_build.yml.