### PR TITLE
FIX: GitHub Actions failures due to encrypted audit logs

### DIFF
--- a/.github/workflows/hsm_tester.yml
+++ b/.github/workflows/hsm_tester.yml
@@ -164,8 +164,10 @@ jobs:
 
     - name: Verify audit log
       run: |
-        grep "KEY_CREATED" hsm_audit.log || exit 1
-        grep "SIGN_OPERATION" hsm_audit.log || exit 1
+        # Audit log is encrypted - use the -audit_logs command to read it
+        ./hsm_enhanced -audit_logs 365 > audit_output.txt
+        grep "KEY_CREATED" audit_output.txt || exit 1
+        grep "SIGN_OPERATION" audit_output.txt || exit 1
         echo "✓ Audit log contains expected entries"
 
     - name: Test enhanced commands

--- a/hsm_security.h
+++ b/hsm_security.h
@@ -123,12 +123,12 @@ int decrypt_key_in_memory(unsigned char *encrypted_key, size_t key_len);
 
 // Implementation
 
-// Static audit encryption key
-static unsigned char audit_enc_key[32] = {0};
-static int audit_enc_key_initialized = 0;
+// Audit encryption key (exported for audit log decryption)
+unsigned char audit_enc_key[32] = {0};
+int audit_enc_key_initialized = 0;
 
-// Initialize audit encryption key
-static void init_audit_encryption_key(void) {
+// Initialize audit encryption key (exported for audit log decryption)
+void init_audit_encryption_key(void) {
     if (audit_enc_key_initialized) {
         return;
     }


### PR DESCRIPTION
This commit fixes all GitHub Actions test failures caused by the encryption changes implemented in the previous commit. The tests were trying to grep encrypted binary audit logs, which fails because the data is no longer plain text.

Changes:

1. Implement Audit Log Decryption (hsm_enhanced.c):
   - Add decrypt_audit_entry_helper() function to decrypt individual audit entries
   - Rewrite handle_list_audit_logs_command() to read encrypted audit logs
   - Support both encrypted (VHSMAUD1 magic) and legacy plain text formats
   - Read format: Magic(8) + [IV(12) + Tag(16) + Ciphertext(sizeof(AuditLogEntry))]*
   - Decrypt each entry and display in human-readable format
   - Filter by timestamp range as before
   - Fixed buffer overflow: GCM mode ciphertext size == plaintext size

2. Export Audit Encryption Functions (hsm_security.h):
   - Change audit_enc_key from static to exported (for decrypt_audit_entry_helper)
   - Change audit_enc_key_initialized from static to exported
   - Change init_audit_encryption_key() from static to exported
   - Allows hsm_enhanced.c to reuse encryption keys for decryption

3. Fix GitHub Actions Workflow (hsm_tester.yml):
   - Replace direct grep on hsm_audit.log (binary encrypted file)
   - Use ./hsm_enhanced -audit_logs 365 command to decrypt and display
   - Redirect output to audit_output.txt for grepping
   - Tests now grep decrypted text output instead of encrypted binary

Testing Performed:
- Built hsm_enhanced successfully (minor truncation warning only)
- Verified audit log encryption works (binary format)
- Tested -audit_logs command decrypts and displays entries correctly
- Verified grep on decrypted output finds KEY_CREATED and SIGN_OPERATION
- Confirmed backward compatibility with plain text audit logs
- Fixed stack smashing error (buffer overflow in ciphertext reading)

Technical Details:
- AES-256-GCM mode: ciphertext length == plaintext length (no padding)
- Each encrypted entry: IV(12) + Tag(16) + Ciphertext(sizeof(AuditLogEntry))
- Decryption validates authentication tag (detects tampering)
- Format detection via magic number comparison
- Proper error handling for incomplete/corrupted entries

This ensures all GitHub Actions tests pass while maintaining full encryption of sensitive audit log data. The -audit_logs command provides authorized access to view encrypted logs for auditing and compliance purposes.